### PR TITLE
Swap out mock

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@fetch-mock/vitest": "^0.2.6",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
         "@types/lodash.debounce": "^4.0.9",
@@ -28,7 +29,6 @@
         "vite": "^6.0.7",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^2.1.8",
-        "vitest-fetch-mock": "^0.3.0",
         "vue-tsc": "^2.2.0"
       },
       "optionalDependencies": {
@@ -494,6 +494,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fetch-mock/vitest": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@fetch-mock/vitest/-/vitest-0.2.6.tgz",
+      "integrity": "sha512-Cj38jbyrPgKosWa4bPhlVaQ5O0po0NbLQ4ZMNEE3FxvIS9M61QSTvcFs6uDn5svPN8pq+FmnbSB9qIo9XoD05A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-mock": "^12.2.0"
+      },
+      "engines": {
+        "node": ">=18.11.0"
+      },
+      "peerDependencies": {
+        "vitest": "*"
+      }
+    },
     "node_modules/@heroicons/vue": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
@@ -884,6 +900,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/glob-to-regexp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@types/glob-to-regexp/-/glob-to-regexp-0.4.4.tgz",
+      "integrity": "sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1571,16 +1594,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1689,6 +1702,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -1871,6 +1894,23 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-mock": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-12.2.0.tgz",
+      "integrity": "sha512-XjgxM582kB0SzPOqH2UdGTwSqga8A8aBPjxcYr0wTeOlCWpZoK6zBrPzltECUTu6Zt3VTWafmKF599LN9BRN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob-to-regexp": "^0.4.4",
+        "dequal": "^2.0.3",
+        "glob-to-regexp": "^0.4.1",
+        "is-subset-of": "^3.1.10",
+        "regexparam": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.11.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1988,6 +2028,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
@@ -2173,6 +2220,17 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-subset-of": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/is-subset-of/-/is-subset-of-3.1.10.tgz",
+      "integrity": "sha512-avvaYgVmYWyaZ1NDFiv4y9JGkrE2je3op1Po4VYKKJKR8H2qVPsg1GZuuXl5elCTxTlwAIsrAjWAs4BVrISFRw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typedescriptor": "3.0.2"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2476,52 +2534,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -2930,6 +2942,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
+      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve": {
@@ -3497,6 +3519,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/typedescriptor": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/typedescriptor/-/typedescriptor-3.0.2.tgz",
+      "integrity": "sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.7.2",
@@ -4189,22 +4219,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest-fetch-mock": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/vitest-fetch-mock/-/vitest-fetch-mock-0.3.0.tgz",
-      "integrity": "sha512-g6upWcL8/32fXL43/5f4VHcocuwQIi9Fj5othcK9gPO8XqSEGtnIZdenr2IaipDr61ReRFt+vaOEgo8jiUUX5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.14.0"
-      },
-      "peerDependencies": {
-        "vitest": ">=2.0.0"
       }
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@fetch-mock/vitest": "^0.2.6",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
     "@types/lodash.debounce": "^4.0.9",
@@ -34,7 +35,6 @@
     "vite": "^6.0.7",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.8",
-    "vitest-fetch-mock": "^0.3.0",
     "vue-tsc": "^2.2.0"
   },
   "optionalDependencies": {

--- a/client/src/__tests__/setup.ts
+++ b/client/src/__tests__/setup.ts
@@ -1,9 +1,5 @@
-import createFetchMock from 'vitest-fetch-mock'
-import { expect, vi } from 'vitest'
-const fetchMocker = createFetchMock(vi)
+import { expect } from 'vitest'
 import { DOMWrapper, VueWrapper } from '@vue/test-utils'
-
-fetchMocker.enableMocks()
 
 // Vue Wrapper helpers
 

--- a/client/src/components/RsvpModal.vue
+++ b/client/src/components/RsvpModal.vue
@@ -167,7 +167,7 @@ const disabled = computed(() => !formData.value.name
                   :class="{
                     'opacity-50 cursor-not-allowed': disabled,
                   }"
-                  @click="rsvp()"
+                  @click="rsvp"
                 >
                   RSVP!
                 </button>

--- a/client/src/components/__tests__/RsvpModal.spec.ts
+++ b/client/src/components/__tests__/RsvpModal.spec.ts
@@ -83,11 +83,11 @@ describe('rsvp submit', () => {
   })
 
   it('calls api with the correct data', async () => {
-    expect({ fetchMock }).toHavePosted('/api/weeks/2020-01-01/rsvp', {
+    expect({ fetchMock }).toHavePosted('/api/weeks/2020-01-01/rsvp', { body: {
       name: 'John Doe',
       email: 'jdoe@example.com',
       reminders: false,
-    })
+    } })
   })
 
   it('closes the modal', async () => {

--- a/client/src/vitest.d.ts
+++ b/client/src/vitest.d.ts
@@ -63,7 +63,10 @@ interface CustomMatchers<R = unknown> {
   ) => R
 
   toHaveDeleted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
-  toHaveLastDeleted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastDeleted: (
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
+  ) => R
   toHaveNthDeleted: (
     n: number,
     filter?: CallHistoryFilter,
@@ -75,7 +78,10 @@ interface CustomMatchers<R = unknown> {
     options?: UserRouteConfig,
   ) => R
 
-  toHaveFetchedHead: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveFetchedHead: (
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
+  ) => R
   toHaveLastFetchedHead: (
     filter?: CallHistoryFilter,
     options?: UserRouteConfig,
@@ -92,7 +98,10 @@ interface CustomMatchers<R = unknown> {
   ) => R
 
   toHavePatched: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
-  toHaveLastPatched: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastPatched: (
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
+  ) => R
   toHaveNthPatched: (
     n: number,
     filter?: CallHistoryFilter,

--- a/client/src/vitest.d.ts
+++ b/client/src/vitest.d.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+
+interface CustomMatchers<R = unknown> {
+  toHaveFetched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastFetched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthFetched: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHaveFetchedTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toBeDone: (routes: RouteName | RouteName[]) => R
+
+  toHaveGot: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastGot: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthGot: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHaveGotTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toHavePosted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastPosted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthPosted: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHavePostedTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toHavePut: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastPut: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthPut: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHavePutTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toHaveDeleted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastDeleted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthDeleted: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHaveDeletedTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toHaveFetchedHead: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastFetchedHead: (
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHaveNthFetchedHead: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHaveFetchedHeadTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+
+  toHavePatched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveLastPatched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveNthPatched: (
+    n: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+  toHavePatchedTimes: (
+    times: number,
+    filter: CallHistoryFilter,
+    options: UserRouteConfig,
+  ) => R
+}
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/client/src/vitest.d.ts
+++ b/client/src/vitest.d.ts
@@ -2,102 +2,106 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+import type { CallHistoryFilter, UserRouteConfig } from 'fetch-mock'
 
 interface CustomMatchers<R = unknown> {
-  toHaveFetched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastFetched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveFetched: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastFetched: (
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
+  ) => R
   toHaveNthFetched: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHaveFetchedTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
   toBeDone: (routes: RouteName | RouteName[]) => R
 
-  toHaveGot: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastGot: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveGot: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastGot: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveNthGot: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHaveGotTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
-  toHavePosted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastPosted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHavePosted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastPosted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveNthPosted: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHavePostedTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
-  toHavePut: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastPut: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHavePut: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastPut: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveNthPut: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHavePutTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
-  toHaveDeleted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastDeleted: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveDeleted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastDeleted: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveNthDeleted: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHaveDeletedTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
-  toHaveFetchedHead: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHaveFetchedHead: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveLastFetchedHead: (
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHaveNthFetchedHead: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHaveFetchedHeadTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 
-  toHavePatched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
-  toHaveLastPatched: (filter: CallHistoryFilter, options: UserRouteConfig) => R
+  toHavePatched: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
+  toHaveLastPatched: (filter?: CallHistoryFilter, options?: UserRouteConfig) => R
   toHaveNthPatched: (
     n: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
   toHavePatchedTimes: (
     times: number,
-    filter: CallHistoryFilter,
-    options: UserRouteConfig,
+    filter?: CallHistoryFilter,
+    options?: UserRouteConfig,
   ) => R
 }
 


### PR DESCRIPTION
At some point `client/src/vitest.d.ts` should go into the consumed repo, but will deal with that later.

Removes vitest mock and uses common `@fetch-mock` packages. 

Will eventually update server to the same.